### PR TITLE
refactor(main): resolve inline comments related to service account / build triggers

### DIFF
--- a/.github/workflows/apply-yor-labels.yaml
+++ b/.github/workflows/apply-yor-labels.yaml
@@ -6,8 +6,6 @@ permissions:
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   yor:


### PR DESCRIPTION
remove hardcoded values were possible. added `google_cloudbuildv2_repository` to create connection to repository using parent connection, no longer requiring manual change in console. added multiple triggers as include `pull_request` and `push` is not valid. lastly changed the name of the cloud build service account to be clearer